### PR TITLE
Latest commits break when viewing certain subscription streams

### DIFF
--- a/twitch.py
+++ b/twitch.py
@@ -128,6 +128,9 @@ class TwitchVideoResolver(object):
         return response.geturl()
 
     def _streamIsAccessible(self, stream):
+        if stream['needed_info'] == "channel_subscription":
+            return False
+
         if not stream.get(Keys.TOKEN) and re.match(Patterns.IP, stream.get(Keys.CONNECT)): 
             return False
         return True


### PR DESCRIPTION
This is a quick hack to fix support for certain channels that have subscriptions for HD content. This effects many of the highest quality SC2 tournaments. I do not really know Python and this may cause unexpected bugs. I just wanted to get this functional ASAP so I could watch WCS Finals on my TV.

Here's the error from xbmc.log:

19:04:29 T:140678877136640   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.TypeError'>
                                            Error Contents: expected string or buffer
                                            Traceback (most recent call last):
                                              File "/home/gary/.xbmc/addons/Twitch.tv-on-XBMC/default.py", line 187, in <module>
                                                PLUGIN.run()
                                              File "/home/gary/.xbmc/addons/script.module.xbmcswift2/lib/xbmcswift2/plugin.py", line 332, in run
                                                items = self._dispatch(self.request.path)
                                              File "/home/gary/.xbmc/addons/script.module.xbmcswift2/lib/xbmcswift2/plugin.py", line 306, in _dispatch
                                                listitems = view_func(*_items)
                                              File "/home/gary/.xbmc/addons/Twitch.tv-on-XBMC/default.py", line 21, in wrapper
                                                return func(_args, **kwargs)
                                              File "/home/gary/.xbmc/addons/Twitch.tv-on-XBMC/default.py", line 141, in playLive
                                                rtmpUrl = resolver.getRTMPUrl(name, videoQuality)
                                              File "/home/gary/.xbmc/addons/Twitch.tv-on-XBMC/twitch.py", line 113, in getRTMPUrl
                                                if self._streamIsAccessible(stream)
                                              File "/home/gary/.xbmc/addons/Twitch.tv-on-XBMC/twitch.py", line 131, in _streamIsAccessible
                                                if not stream.get(Keys.TOKEN) and re.match(Patterns.IP, stream.get(Keys.CONNECT)):
                                              File "/usr/lib/python2.7/re.py", line 137, in match
                                                return _compile(pattern, flags).match(string)
                                            TypeError: expected string or buffer
                                            -->End of Python script error report<--
19:04:29 T:140680355063744   ERROR: Playlist Player: skipping unplayable item: 0, path [plugin://plugin.video.twitch/playLive/wcs_gsl/]
