### PR TITLE
Changed the default limit of following channels. Fixes issue #25.

### DIFF
--- a/twitch.py
+++ b/twitch.py
@@ -216,7 +216,7 @@ class Urls(object):
     TWITCH_TV = 'http://www.twitch.tv/'
 
     BASE = 'https://api.twitch.tv/kraken/'
-    FOLLOWED_CHANNELS =  BASE + 'users/{0}/follows/channels'
+    FOLLOWED_CHANNELS =  BASE + 'users/{0}/follows/channels?limit=100'
     GAMES = BASE + 'games/'
     STREAMS = BASE + 'streams/'
     SEARCH = BASE + 'search/'


### PR DESCRIPTION
Changed the default limit of following-channels to display to 100; it will now correctly display all the channels if you follow more than 25 of them. This is just a hotfix, I'm sure a more elegant solution can be found.

This fixes issue #25. Credit to @grocal for the solution.
