### PR TITLE
Fixing the viewer count

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id='plugin.video.twitch' version='1.0.3' name='TwitchTV' provider-name='StateOfTheArt and ccaspers'>
+﻿<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<addon id='plugin.video.twitch' version='1.0.4' name='TwitchTV' provider-name='StateOfTheArt, ccaspers and CDehning'>
   <requires>
     <import addon='xbmc.python' version='2.1.0'/>
     <import addon='script.module.simplejson' version='2.0.10'/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
-﻿<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id='plugin.video.twitch' version='1.0.4' name='TwitchTV' provider-name='StateOfTheArt, ccaspers and CDehning'>
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<addon id='plugin.video.twitch' version='1.0.4' name='TwitchTV' provider-name='StateOfTheArt and ccaspers'>
   <requires>
     <import addon='xbmc.python' version='2.1.0'/>
     <import addon='script.module.simplejson' version='2.0.10'/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -49,4 +49,6 @@
 1.0.2
 - fixed stream resolving
 1.0.3
-- added support for HLS streams 
+- added support for HLS streams
+1.0.4
+- fixed bug: Viewer count could not be resolved

--- a/converter.py
+++ b/converter.py
@@ -40,37 +40,6 @@ class JsonListItemConverter(object):
                 'is_playable': True,
                 'icon': image}
 
-    def extractStreamTitleValues(self, stream):
-        channel = stream[Keys.CHANNEL]
-        print json.dumps(channel, indent=4, sort_keys=True)
-        return {'streamer': channel.get(Keys.DISPLAY_NAME,
-                                        self.plugin.get_string(34000)),
-                'title': channel.get(Keys.STATUS,
-                                     self.plugin.get_string(34001)),
-                'viewers': stream.get(Keys.VIEWERS,
-                                       self.plugin.get_string(34002))
-                }
-
-    def extractTitleValues(self, channel):
-        print json.dumps(channel, indent=4, sort_keys=True)
-        return {'streamer': channel.get(Keys.DISPLAY_NAME,
-                                        self.plugin.get_string(34000)),
-                'title': channel.get(Keys.STATUS,
-                                     self.plugin.get_string(34001)),
-                'viewers': channel.get(Keys.VIEWERS,
-                                       self.plugin.get_string(34002))
-                }
-
-    def convertChannelToListItem(self, channel):
-        videobanner = channel.get(Keys.VIDEO_BANNER, '')
-        logo = channel.get(Keys.LOGO, '')
-        return {'label': self.getTitleForChannel(channel),
-                'path': self.plugin.url_for(endpoint='playLive',
-                                            name=channel[Keys.NAME]),
-                'is_playable': True,
-                'icon': videobanner if videobanner else logo
-                }
-
     def convertStreamToListItem(self, stream):
         channel = stream[Keys.CHANNEL]
         videobanner = channel.get(Keys.VIDEO_BANNER, '')
@@ -81,15 +50,26 @@ class JsonListItemConverter(object):
                 'is_playable': True,
                 'icon': videobanner if videobanner else logo
         }
-        
-    def getTitleForChannel(self, channel):
-        titleValues = self.extractTitleValues(channel)
-        return self.titleBuilder.formatTitle(titleValues)
 
     def getTitleForStream(self, stream):
         titleValues = self.extractStreamTitleValues(stream)
         return self.titleBuilder.formatTitle(titleValues)
-    
+
+    def extractStreamTitleValues(self, stream):
+        channel = stream[Keys.CHANNEL]
+        print json.dumps(channel, indent=4, sort_keys=True)
+
+        if Keys.VIEWERS in channel:
+            viewers = channel.get(Keys.VIEWERS);
+        else:
+            viewers = stream.get(Keys.VIEWERS, self.plugin.get_string(34002))
+
+        return {'streamer': channel.get(Keys.DISPLAY_NAME,
+                                        self.plugin.get_string(34000)),
+                'title': channel.get(Keys.STATUS,
+                                     self.plugin.get_string(34001)),
+                'viewers': viewers}
+
 class TitleBuilder(object):
 
     class Templates(object):

--- a/default.py
+++ b/default.py
@@ -62,9 +62,9 @@ def createMainListing():
 @PLUGIN.route('/createListOfFeaturedStreams/')
 @managedTwitchExceptions
 def createListOfFeaturedStreams():
-    streams = TWITCHTV.getFeaturedStream()
-    return [CONVERTER.convertChannelToListItem(element[Keys.STREAM][Keys.CHANNEL])
-            for element in streams]
+    featuredStreams = TWITCHTV.getFeaturedStream()
+    return [CONVERTER.convertStreamToListItem(featuredStream[Keys.STREAM])
+            for featuredStream in featuredStreams]
 
 
 @PLUGIN.route('/createListOfGames/<index>/')
@@ -83,7 +83,7 @@ def createListOfGames(index):
 @managedTwitchExceptions
 def createListForGame(gameName, index):
     index, offset, limit = calculatePaginationValues(index)
-    items = [CONVERTER.convertChannelToListItem(item[Keys.CHANNEL])for item
+    items = [CONVERTER.convertStreamToListItem(stream) for stream
              in TWITCHTV.getGameStreams(gameName, offset, limit)]
 
     items.append(linkToNextPage('createListForGame', index, gameName=gameName))
@@ -95,7 +95,7 @@ def createListForGame(gameName, index):
 def createFollowingList():
     username = getUserName()
     streams = TWITCHTV.getFollowingStreams(username)
-    return [CONVERTER.convertChannelToListItem(stream[Keys.CHANNEL]) for stream in streams]
+    return [CONVERTER.convertStreamToListItem(stream) for stream in streams]
 
 
 @PLUGIN.route('/search/')
@@ -115,7 +115,7 @@ def searchresults(query, index='0'):
     index, offset, limit = calculatePaginationValues(index)
     streams = TWITCHTV.searchStreams(query, offset, limit)
 
-    items = [CONVERTER.convertChannelToListItem(stream[Keys.CHANNEL]) for stream in streams]
+    items = [CONVERTER.convertStreamToListItem(stream) for stream in streams]
     items.append(linkToNextPage('searchresults', index, query=query))
     return items
 


### PR DESCRIPTION
These changes should fix the following issue:
https://github.com/StateOfTheArt89/Twitch.tv-on-XBMC/issues/37

Basically, Twitch has an inconsistent API when it comes to the viewer counts. In the call for featured streams, they pass it in with the Channel element. But everywhere else it is one level above that... 

I tested that is works on my RaspBMC.  

Edit: It worked until I uploaded this to Github at least. If I download it as a zip-file from Github, i cannot install it as a zip file anymore... Any idea?
