### PR TITLE
Added ability to play archived videos (past broadcasts)

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id='plugin.video.twitch' version='1.0.3' name='TwitchTV' provider-name='StateOfTheArt and ccaspers'>
+<addon id='plugin.video.twitch' version='1.0.4' name='TwitchTV' provider-name='StateOfTheArt and ccaspers'>
   <requires>
     <import addon='xbmc.python' version='2.1.0'/>
     <import addon='script.module.simplejson' version='2.0.10'/>

--- a/converter.py
+++ b/converter.py
@@ -70,6 +70,22 @@ class JsonListItemConverter(object):
                 'is_playable': True,
                 'icon': videobanner if videobanner else logo
                 }
+                
+    def convertFollowersToListItem(self, follower):
+        videobanner = follower.get(Keys.LOGO, '')
+        return {'label': follower[Keys.DISPLAY_NAME],
+                'path': self.plugin.url_for(endpoint='channelVideos',
+                                            name=follower[Keys.NAME]),
+                'icon': videobanner
+                }
+                
+    def convertVideoListToListItem(self,video):
+        return {'label': video['title'],
+                'path': self.plugin.url_for(endpoint='playVideo',
+                                            id=video['_id']),
+                'is_playable': True,
+                'icon': video.get(Keys.PREVIEW, '')
+                }
 
     def convertStreamToListItem(self, stream):
         channel = stream[Keys.CHANNEL]

--- a/default.py
+++ b/default.py
@@ -95,9 +95,56 @@ def createListForGame(gameName, index):
 def createFollowingList():
     username = getUserName()
     streams = TWITCHTV.getFollowingStreams(username)
-    return [CONVERTER.convertChannelToListItem(stream[Keys.CHANNEL]) for stream in streams]
+    liveStreams = [CONVERTER.convertChannelToListItem(stream[Keys.CHANNEL]) for stream in streams['live']]
+    liveStreams.insert(0,{'path': PLUGIN.url_for(endpoint='createFollowingList'), 'icon': u'', 'is_playable': False, 'label': u'-- Currently Live Streams --'})
+    liveStreams.append({'path': PLUGIN.url_for(endpoint='createFollowingList'), 'icon': u'', 'is_playable': False, 'label': u'-- Followed Channels --'})
+    liveStreams.extend([CONVERTER.convertFollowersToListItem(follower) for follower in streams['others']])
+    return liveStreams
 
 
+@PLUGIN.route('/channelVideos/<name>/')
+@managedTwitchExceptions
+def channelVideos(name):
+    items = [
+        {'label': 'Past Broadcasts',
+         'path': PLUGIN.url_for(endpoint='channelVideosList', name=name, index=0, past='true')
+        },
+        {'label': 'Video Highlights',
+         'path': PLUGIN.url_for(endpoint='channelVideosList', name=name, index=0, past='false')
+        }
+    ]
+    return items
+    
+    
+@PLUGIN.route('/channelVideosList/<name>/<index>/<past>/')
+@managedTwitchExceptions
+def channelVideosList(name,index,past):
+    index = int(index)
+    offset = index * 8
+    videos = TWITCHTV.getFollowerVideos(name,offset,past)
+    items = [CONVERTER.convertVideoListToListItem(video) for video in videos[Keys.VIDEOS]]
+    if videos[Keys.TOTAL] > (offset + 8):
+        items.append(linkToNextPage('channelVideosList', index, name=name, past=past))
+    return items
+    
+    
+@PLUGIN.route('/playVideo/<id>/')
+@managedTwitchExceptions
+def playVideo(id):
+    
+    playList = TWITCHTV.getVideoChunksPlaylist(id)
+    
+    # Doesn't fullscreen video, might be because of xbmcswift
+    #xbmc.Player().play(playlist) 
+    
+    try:
+        # Gotta wrap this in a try/except, xbmcswift causes an error when passing a xbmc.PlayList()
+        # but still plays the playlist properly
+        PLUGIN.set_resolved_url(playlist)
+    except:
+        pass
+    
+    
 @PLUGIN.route('/search/')
 @managedTwitchExceptions
 def search():
@@ -124,8 +171,8 @@ def searchresults(query, index='0'):
 def showSettings():
     #there is probably a better way to do this
     PLUGIN.open_settings()
-
-
+    
+    
 @PLUGIN.route('/playLive/<name>/')
 @managedTwitchExceptions
 def playLive(name):

--- a/twitch.py
+++ b/twitch.py
@@ -1,7 +1,7 @@
 #-*- encoding: utf-8 -*-
 import urllib2, sys
 from urllib import quote_plus
-import re
+import re, xbmcgui, xbmc
 try:
     import json
 except:
@@ -74,10 +74,45 @@ class TwitchTV(object):
         #Get ChannelNames
         followingChannels = self.getFollowingChannelNames(username)
         channelNames = self._filterChannelNames(followingChannels)
+
         #get Streams of that Channels
-        options = '?channel=' + ','.join(channelNames)
+        options = '?channel=' + ','.join([channels[Keys.NAME] for channels in channelNames])
         url = ''.join([Urls.BASE, Keys.STREAMS, options])
-        return self._fetchItems(url, Keys.STREAMS)
+        channels = {'live' : self._fetchItems(url, Keys.STREAMS)}
+        channels['others'] = channelNames
+        return channels
+        
+    def getFollowerVideos(self, username, offset, past):
+        url = Urls.CHANNEL_VIDEOS.format(username,offset,past)
+        items = self.scraper.getJson(url)
+        return {Keys.TOTAL : items[Keys.TOTAL], Keys.VIDEOS : items[Keys.VIDEOS]}
+        
+    def getVideoChunks(self, id):
+        url = Urls.VIDEO_CHUNKS.format(id)
+        return self.scraper.getJson(url)
+        
+    def getVideoTitle(self, id):
+        url = Urls.VIDEO_INFO.format(id)
+        return self._fetchItems(url, 'title')
+        
+    def getVideoChunksPlaylist(self, id):
+        vidChunks = self.getVideoChunks(id)
+        chunks = vidChunks['chunks']['live']
+        title = self.getVideoTitle(id)
+        itemTitle = '%s - Part {0} of %s' % (title, len(chunks))
+
+        playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
+        playlist.clear()
+        
+        # For some reason first item is skipped, so added a dummy first item to fix
+        # theres probably a better way
+        playlist.add('', xbmcgui.ListItem('', thumbnailImage=vidChunks['preview']))
+        curN = 0
+        for chunk in chunks:
+            curN += 1
+            playlist.add(chunk['url'], xbmcgui.ListItem(itemTitle.format(curN), thumbnailImage=vidChunks['preview']))
+            
+        return playlist
 
     def getFollowingChannelNames(self, username):
         quotedUsername = quote_plus(username)
@@ -97,7 +132,8 @@ class TwitchTV(object):
         return self._fetchItems(url, Keys.CHANNELS)
 
     def _filterChannelNames(self, channels):
-        return [item[Keys.CHANNEL][Keys.NAME] for item in channels]
+        tmp = [{Keys.DISPLAY_NAME : item[Keys.CHANNEL][Keys.DISPLAY_NAME], Keys.NAME : item[Keys.CHANNEL][Keys.NAME], Keys.LOGO : item[Keys.CHANNEL][Keys.LOGO]} for item in channels]
+        return sorted(tmp, key=lambda k: k[Keys.DISPLAY_NAME]) 
 
     def _fetchItems(self, url, key):
         items = self.scraper.getJson(url)
@@ -249,10 +285,14 @@ class Keys(object):
     TEAMS = 'teams'
     TOKEN = 'token'
     TOP = 'top'
+    TOTAL = '_total'
     USER_AGENT = 'User-Agent'
+    VIDEOS = "videos"
     VIDEO_BANNER = 'video_banner'
     VIDEO_HEIGHT = 'video_height'
     VIEWERS = 'viewers'
+    PREVIEW = 'preview'
+    TITLE = 'title'
 
 
 class Patterns(object):
@@ -290,6 +330,10 @@ class Urls(object):
     TWITCH_SWF = "http://www.justin.tv/widgets/live_embed_player.swf?channel="
     FORMAT_FOR_RTMP = "{rtmp}/{playpath} swfUrl={swfUrl} swfVfy=1 {token} live=1"  # Pageurl missing here
     HLS_PLAYLIST = 'http://usher.twitch.tv/select/{0}.m3u8?nauthsig={1}&nauth={2}&allow_source=true'
+    
+    CHANNEL_VIDEOS = 'https://api.twitch.tv/kraken/channels/{0}/videos?limit=8&offset={1}&broadcasts={2}'
+    VIDEO_CHUNKS = 'https://api.twitch.tv/api/videos/{0}'
+    VIDEO_INFO = 'https://api.twitch.tv/kraken/videos/{0}'
         
 
 


### PR DESCRIPTION
Allows playing of past broadcasts and saved video highlights.

The followers list will now show Live channels at the top, and all the channels you follow underneath. Selecting a channel will give you 2 options, past broadcasts and video highlights.

Twitch splits archived videos into 30 minute segments, so I just got a list of all the segments then created a playlist with them using "xbmc.PlayList()"

I tried to stick to the code layout you use, but it still might need some refactoring.
