### PR TITLE
Fixed Quality Settings Bug

### DIFF
--- a/twitch.py
+++ b/twitch.py
@@ -192,13 +192,20 @@ class TwitchVideoResolver(object):
             quality = 'Source,High,Medium,Low'
             quality = quality.split(',')
 
-            #Loop Through Multiple Quality Stream Playlist Until We Find Our Preferred Quality
-            for line in range(0, (len(streamurls)-1)):
-                if quality[maxQuality] in streamurls[line]:
-                    #Add 3 Quality Specific Applicable Lines From Multiple Quality Stream Playlist To Our Custom Playlist Var
-                    playlist = playlist + streamurls[line] + '\n' + streamurls[(line + 1)] + '\n' + streamurls[(line + 2)]
-                    print(playlist)
-
+            #Check to see if our preferred quality is available (not all qualities are available for none partnered streams)
+            if quality[maxQuality] in data:
+                #Preferred quality is available
+                #Loop Through Multiple Quality Stream Playlist Until We Find Our Preferred Quality
+                for line in range(0, (len(streamurls)-1)):
+                    if quality[maxQuality] in streamurls[line]:
+                        #Add 3 Quality Specific Applicable Lines From Multiple Quality Stream Playlist To Our Custom Playlist Var
+                        playlist = playlist + streamurls[line] + '\n' + streamurls[(line + 1)] + '\n' + streamurls[(line + 2)]
+                        print(playlist)
+            else:
+                #Preferred quality is unavailable so let's play the raw playlist we got from twitch (contains only 'source')
+                playlist = data
+                print(playlist)
+                
             #Write Custom Playlist
             text_file = open(fileName, "w")
             text_file.write(str(playlist))


### PR DESCRIPTION
Fixed a bug where a blank playlist is generated when a user attempts to load a stream which does not have their preferred quality available. 

Addon now checks that the preferred quality is available for the stream being requested and defaults to the playlist provided by Twitch's API in the case that multiple qualities are not available (eg: unpartnered small streams).

This should fix the issue raised in #56 
