### PR TITLE
changed game thumbnail source

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -10,7 +10,7 @@ class JsonListItemConverter(object):
 
     def convertGameToListItem(self, game):
         name = game[Keys.NAME].encode('utf-8')
-        image = game[Keys.LOGO].get(Keys.LARGE, '')
+        image = game[Keys.BOX].get(Keys.LARGE, '')
         return {'label': name,
                 'path': self.plugin.url_for('createListForGame',
                                             gameName=name, index='0'),

--- a/twitch.py
+++ b/twitch.py
@@ -292,6 +292,7 @@ class Keys(object):
     FOLLOWS = 'follows'
     GAME = 'game'
     LOGO = 'logo'
+    BOX = 'box'
     LARGE = 'large'
     NAME = 'name'
     NEEDED_INFO = 'needed_info'


### PR DESCRIPTION
This is merely a suggestion, not a bugfix:
A lot of games (especially newer ones) don't have a thumbnail picture when taken from the "logo" index in the Twitch API. Conveniently, the API also provides the "box" index for box/poster art, as it can be seen here: http://www.twitch.tv/directory

In my opinion this also fits the overall style of XBMC better than the logo since the box art has basically the same aspect ratio as movie posters.
