### PR TITLE
Add listing streams by Channels.

### DIFF
--- a/default.py
+++ b/default.py
@@ -43,6 +43,9 @@ def createMainListing():
         {'label': PLUGIN.get_string(30001),
          'path': PLUGIN.url_for(endpoint='createListOfGames', index='0')
          },
+        {'label': PLUGIN.get_string(30008),
+         'path': PLUGIN.url_for(endpoint='createListOfChannels', index='0')
+         },
         {'label': PLUGIN.get_string(30002),
          'path': PLUGIN.url_for(endpoint='createFollowingList')
          },
@@ -76,6 +79,17 @@ def createListOfGames(index):
     items = [CONVERTER.convertGameToListItem(element[Keys.GAME]) for element in games]
 
     items.append(linkToNextPage('createListOfGames', index))
+    return items
+
+
+@PLUGIN.route('/createListOfChannels/<index>/')
+@managedTwitchExceptions
+def createListOfChannels(index):
+    index, offset, limit = calculatePaginationValues(index)
+    items = [CONVERTER.convertStreamToListItem(stream) for stream
+             in TWITCHTV.getChannels(offset, limit)]
+
+    items.append(linkToNextPage('createListOfChannels', index))
     return items
 
 

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
   <!-- main menu -->
   <string id="30001">Hry</string>
@@ -7,6 +7,7 @@
   <string id="30004">Nastavení</string>
   <string id="30005">Nejlepší streamy</string>
   <string id="30006">Týmy</string>
+  <string id="30008">Kanály</string>
   
   <!--search -->
   <string id="30007">Hledat kanál</string>

--- a/resources/language/Dutch/strings.xml
+++ b/resources/language/Dutch/strings.xml
@@ -7,6 +7,7 @@
   <string id="30004">Instellingen</string>
   <string id="30005">Streams</string>
   <string id="30006">Teams</string>
+  <string id="30008">Kanalen</string>
   
   <!--search -->
   <string id="30007">Zoeken naar kanalen</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -7,6 +7,7 @@
   <string id="30004">Settings</string>
   <string id="30005">Featured Streams</string>
   <string id="30006">Teams</string>
+  <string id="30008">Channels</string>
   
   <!--search -->
   <string id="30007">Search for channels</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -7,6 +7,7 @@
   <string id="30004">Einstellungen</string>
   <string id="30005">Featured Streams</string>
   <string id="30006">Teams</string>
+  <string id="30008">Kanäle</string>
   
   <!-- search -->
   <string id="30007">Suche nach Kanälen</string>

--- a/resources/language/Polish/strings.xml
+++ b/resources/language/Polish/strings.xml
@@ -7,6 +7,7 @@
   <string id="30004">Ustawienia</string>
   <string id="30005">Popularne kanały</string>
   <string id="30006">Drużyny</string>
+  <string id="30008">Kanaly</string>
   
   <!--search -->
   <string id="30007">Szukaj kanałów</string>

--- a/twitch.py
+++ b/twitch.py
@@ -84,6 +84,11 @@ class TwitchTV(object):
         url = ''.join([Urls.GAMES, Keys.TOP, options])
         return self._fetchItems(url, Keys.TOP)
 
+    def getChannels(self, offset=10, limit=10):
+        options = Urls.OPTIONS_OFFSET_LIMIT.format(offset, limit)
+        url = ''.join([Urls.STREAMS, options])
+        return self._fetchItems(url, Keys.STREAMS)
+
     def getGameStreams(self, gameName, offset=10, limit=10):
         quotedName = quote_plus(gameName)
         options = Urls.OPTIONS_OFFSET_LIMIT_GAME.format(offset, limit, quotedName)


### PR DESCRIPTION
Added functionality for listing streams sorted by amount of viewers,
as seen when clicking "Channels" on twitch.tv. I don't actually know
any of the supported languages except English. The strings for other
languages were taken from the Twitch.tv site, by changing the site's
language. However, I couldn't find Czech on Twitch.tv, so it uses
Google Translate.

I don't know of the naming convention used in the localization files,
so I just gave the string ID 30008.
