### PR TITLE
UNTESTED: expand getVideoChunksPlaylist to look for quality

### DIFF
--- a/default.py
+++ b/default.py
@@ -145,8 +145,9 @@ def channelVideosList(name,index,past):
 @PLUGIN.route('/playVideo/<id>/')
 @managedTwitchExceptions
 def playVideo(id):
-    
-    playList = TWITCHTV.getVideoChunksPlaylist(id)
+    #Get Required Quality From Settings
+    videoQuality = getVideoQuality()
+    playList = TWITCHTV.getVideoChunksPlaylist(id,videoQuality)
     
     # Doesn't fullscreen video, might be because of xbmcswift
     #xbmc.Player().play(playlist) 


### PR DESCRIPTION
first step towards resolving #81.

old broadcasts _can_ have multiple resolutions, see https://api.twitch.tv/api/videos/c5039141

thisdoes not respect `maxQuality` like it should. on the other hand, `saveHLSToPlaylist` does not as well.

while there is `_bestMatchForChosenQuality` it won't work in those cases, how quality is handled needs to be reworked in all those functions to have a single choosing or ordering function (which returns a list like [choosen | best<maxQuality | nextBest<maxQuality|...]
