### PR TITLE
"Streamer - game - title" listing, ellipsis option and Polish translations

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -91,6 +91,8 @@ class JsonListItemConverter(object):
                                         self.plugin.get_string(30060)),
                 'title': channel.get(Keys.STATUS,
                                      self.plugin.get_string(30061)),
+                'game': channel.get(Keys.GAME,
+                                     self.plugin.get_string(30064)),
                 'viewers': viewers}
 
 class TitleBuilder(object):
@@ -100,6 +102,7 @@ class TitleBuilder(object):
         STREAMER = u"{streamer}"
         STREAMER_TITLE = u"{streamer} - {title}"
         VIEWERS_STREAMER_TITLE = u"{viewers} - {streamer} - {title}"
+        STREAMER_GAME_TITLE = u"{streamer} - {game} - {title}"
         ELLIPSIS = u'...'
 
     def __init__(self, PLUGIN, line_length):
@@ -120,7 +123,8 @@ class TitleBuilder(object):
         options = {0: TitleBuilder.Templates.STREAMER_TITLE,
                    1: TitleBuilder.Templates.VIEWERS_STREAMER_TITLE,
                    2: TitleBuilder.Templates.TITLE,
-                   3: TitleBuilder.Templates.STREAMER}
+                   3: TitleBuilder.Templates.STREAMER,
+                   4: TitleBuilder.Templates.STREAMER_GAME_TITLE}
         return options.get(titleSetting, TitleBuilder.Templates.STREAMER)
 
     def cleanTitleValue(self, value):
@@ -129,7 +133,13 @@ class TitleBuilder(object):
         else:
             return value
 
-    def truncateTitle(self, title):
-        shortTitle = title[:self.line_length]
-        ending = (title[self.line_length:] and TitleBuilder.Templates.ELLIPSIS)
-        return shortTitle + ending
+    def truncateTitle(self, title):        
+        truncateSetting = self.plugin.get_setting('titletruncate', unicode)
+
+        if truncateSetting == "true":
+            shortTitle = title[:self.line_length]
+            ending = (title[self.line_length:] and TitleBuilder.Templates.ELLIPSIS)
+            return shortTitle + ending
+        else:
+            return title
+        return title

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -42,6 +42,7 @@
   <string id="30047">Sledující - Streamer - Název streamu</string>
   <string id="30048">Název streamu</string>
   <string id="30049">Streamer</string>
+  <string id="30051">Streamer - Název hry - Název streamu</string>
 
   <string id="30050">Uživatelské jméno</string>
   
@@ -49,5 +50,8 @@
   <string id="30060">Bezejmenný Streamer</string>
   <string id="30061">Stream bez názvu</string>
   <string id="30062">Neznámý počet sledujících</string>
+  <string id="30064">Unknown Game</string>
+
+  <string id="30065">Truncate displayed titles</string>
 
 </strings>

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -50,8 +50,8 @@
   <string id="30060">Bezejmenný Streamer</string>
   <string id="30061">Stream bez názvu</string>
   <string id="30062">Neznámý počet sledujících</string>
-  <string id="30064">Unknown Game</string>
+  <string id="30064">Neznámá hra</string>
 
-  <string id="30065">Truncate displayed titles</string>
+  <string id="30065">Zkrátit zobrazené tituly</string>
 
 </strings>

--- a/resources/language/Dutch/strings.xml
+++ b/resources/language/Dutch/strings.xml
@@ -50,8 +50,8 @@
   <string id="30060">Naamloze Streamer</string>
   <string id="30061">Naamloze Stream</string>
   <string id="30062">Onbekend Aantal Kijkers</string>
-  <string id="30064">Unknown Game</string>
+  <string id="30064">Onbekend Spel</string>
 
-  <string id="30065">Truncate displayed titles</string>
+  <string id="30065">Afkappen weergegeven titels</string>
 
 </strings>

--- a/resources/language/Dutch/strings.xml
+++ b/resources/language/Dutch/strings.xml
@@ -42,6 +42,7 @@
   <string id="30047">Kijkers - Streamer - Stream Titel</string>
   <string id="30048">Stream Titel</string>
   <string id="30049">Streamer</string>
+  <string id="30051">Streamer - Game Title - Stream Title</string>
 
   <string id="30050">Gebruikersnaam</string>
   
@@ -49,5 +50,8 @@
   <string id="30060">Naamloze Streamer</string>
   <string id="30061">Naamloze Stream</string>
   <string id="30062">Onbekend Aantal Kijkers</string>
+  <string id="30064">Unknown Game</string>
+
+  <string id="30065">Truncate displayed titles</string>
 
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -42,6 +42,7 @@
   <string id="30047">Viewers - Streamer - Stream Title</string>
   <string id="30048">Stream Title</string>
   <string id="30049">Streamer</string>
+  <string id="30051">Streamer - Game Title - Stream Title</string>
 
   <string id="30050">Username</string>
   
@@ -49,5 +50,8 @@
   <string id="30060">Unnamed Streamer</string>
   <string id="30061">Untitled Stream</string>
   <string id="30062">Unknown Number of Viewers</string>
+  <string id="30064">Unknown Game</string>
+
+  <string id="30065">Truncate displayed titles</string>
 
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -51,8 +51,8 @@
   <string id="30060">Unbenannter Streamer</string>
   <string id="30061">Unbenannter Stream</string>
   <string id="30062">Unbekannte Zuschauerzahl</string>
-  <string id="30064">Unknown Game</string>
+  <string id="30064">Unbekannt Game</string>
 
-  <string id="30065">Truncate displayed titles</string>
+  <string id="30065">Abschneiden angezeigt Titel</string>
 
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -43,6 +43,7 @@
   <string id="30047">Zuschauerzahl - Streamer - Status</string>
   <string id="30048">Status</string>
   <string id="30049">Streamer</string>
+  <string id="30051">Streamer - Game Title - Stream Title</string>
 
   <string id="30050">Benutzername</string>
   
@@ -50,4 +51,8 @@
   <string id="30060">Unbenannter Streamer</string>
   <string id="30061">Unbenannter Stream</string>
   <string id="30062">Unbekannte Zuschauerzahl</string>
+  <string id="30064">Unknown Game</string>
+
+  <string id="30065">Truncate displayed titles</string>
+
 </strings>

--- a/resources/language/Polish/strings.xml
+++ b/resources/language/Polish/strings.xml
@@ -15,8 +15,8 @@
   <!--general --> 
   <string id="30010">TwitchTV</string>
   <string id="30011">następne...</string>
-  <string id="30012">-- Currently Live Streams --</string>
-  <string id="30013">-- Followed Channels --</string>
+  <string id="30012">-- Kanały na żywo --</string>
+  <string id="30013">-- Obserwowane kanały --</string>
 
    <!--notifications --> 
   <string id="30020">Błąd HTTP</string>
@@ -42,6 +42,15 @@
   <string id="30047">Liczba oglądających - Kanał - Tytuł</string>
   <string id="30048">Tytuł</string>
   <string id="30049">Kanał</string>
+  <string id="30051">Kanał - Gra - Tytuł</string>
   
   <string id="30050">Użytkownik</string>
+
+  <string id="30060">Kanał bez nazwy</string>
+  <string id="30061">Kanał bez tytułu</string>
+  <string id="30062">Nieznana liczba oglądających</string>
+  <string id="30064">Unknown Game</string>
+
+  <string id="30065">Skracaj za długie tytuły</string>
+
 </strings>

--- a/resources/language/Polish/strings.xml
+++ b/resources/language/Polish/strings.xml
@@ -49,7 +49,7 @@
   <string id="30060">Kanał bez nazwy</string>
   <string id="30061">Kanał bez tytułu</string>
   <string id="30062">Nieznana liczba oglądających</string>
-  <string id="30064">Unknown Game</string>
+  <string id="30064">Nieznana gra</string>
 
   <string id="30065">Skracaj za długie tytuły</string>
 

--- a/resources/language/Polish/strings.xml
+++ b/resources/language/Polish/strings.xml
@@ -7,7 +7,7 @@
   <string id="30004">Ustawienia</string>
   <string id="30005">Popularne kanały</string>
   <string id="30006">Drużyny</string>
-  <string id="30008">Kanaly</string>
+  <string id="30008">Kanały</string>
   
   <!--search -->
   <string id="30007">Szukaj kanałów</string>
@@ -51,6 +51,6 @@
   <string id="30062">Nieznana liczba oglądających</string>
   <string id="30064">Nieznana gra</string>
 
-  <string id="30065">Skracaj za długie tytuły</string>
+  <string id="30065">Skracaj zbyt długie tytuły</string>
 
 </strings>

--- a/resources/language/Spanish/strings.xml
+++ b/resources/language/Spanish/strings.xml
@@ -44,7 +44,7 @@
 <string id="30060">Streamer sin nombre</string>
 <string id="30061">Stream sin título</string>
 <string id="30062">Número desconocido de espectadores</string>
-<string id="30064">Unknown Game</string>
+<string id="30064">Juego desconocido</string>
 
-<string id="30065">Truncate displayed titles</string>
+<string id="30065">Truncar títulos exhibidos</string>
 </strings>

--- a/resources/language/Spanish/strings.xml
+++ b/resources/language/Spanish/strings.xml
@@ -38,9 +38,13 @@
 <string id="30047">Espectadores - Streamer - Título del Stream</string>
 <string id="30048">Título del Stream</string>
 <string id="30049">Streamer</string>
+<string id="30051">Streamer - Game Title - Stream Title</string>
 <string id="30050">Nombre de usuario</string>
 <!--title-->
 <string id="30060">Streamer sin nombre</string>
 <string id="30061">Stream sin título</string>
 <string id="30062">Número desconocido de espectadores</string>
+<string id="30064">Unknown Game</string>
+
+<string id="30065">Truncate displayed titles</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,6 +6,8 @@
 		<!-- Video Quality -->
 		<setting id="video" type="enum" label="30040" lvalues="30041|30042|30043|30044|30063" default="0" />
 		<!-- Title Display -->
-		<setting id="titledisplay" type="enum" label="30045" lvalues="30046|30047|30048|30049" default="0" />
+		<setting id="titledisplay" type="enum" label="30045" lvalues="30046|30047|30048|30049|30051" default="0" />
+		<!-- Truncate titles -->
+		<setting id="titletruncate" type="bool" label="30065" default="true" />
 	</category>
 </settings>

--- a/twitch.py
+++ b/twitch.py
@@ -182,7 +182,7 @@ class TwitchTV(object):
 
     def _filterChannelNames(self, channels):
         tmp = [{Keys.DISPLAY_NAME : item[Keys.CHANNEL][Keys.DISPLAY_NAME], Keys.NAME : item[Keys.CHANNEL][Keys.NAME], Keys.LOGO : item[Keys.CHANNEL][Keys.LOGO]} for item in channels]
-        return sorted(tmp, key=lambda k: k[Keys.DISPLAY_NAME]) 
+        return sorted(tmp, key=lambda k: k[Keys.DISPLAY_NAME].lower()) 
 
     def _fetchItems(self, url, key):
         items = self.scraper.getJson(url)


### PR DESCRIPTION
Hello!

:information_source: These are just proposals so feel free to discuss and decide if those changes should go into the main app.

I was missing couple of options in Twitch.tv XBMC plugin. First was **ability to show up stream title as "Streamer - game - stream title"** template. With followed streamers streaming different games and not always stating that in title I thought that giving users such option would be helpful. Second option is **checkbox option whether user shall see titles truncated to 60 characters with ellipsis in the end** or title should be presented without truncation. XBMC is scrolling titles anyway and - in my opinion - it's better to see full info rather the have title chopped.

I've also prepared **translation for new strings** in languages which I'm aware of and **fixed some missing Polish translations**.

Last thing was _change sorting_ followed channels which are offline. I think case insensitive sorting is better. With that I have entries like _dota2_ and _Dota2_something_ right beside each other rather than scrolling after "Z" to see lower-cased titles.

All and all - thanks for the greatest plugin for XBMC! Keep up the good work, guys!

**New options**
![screenshot004](https://cloud.githubusercontent.com/assets/896246/4465766/4e7b5d4e-48de-11e4-8972-51ca83483ee0.png)

**Scrolling title**
![screenshot003](https://cloud.githubusercontent.com/assets/896246/4465764/4e79c1a0-48de-11e4-95f2-344fcf65e466.png)

**Sorting case insensitive**
![screenshot005](https://cloud.githubusercontent.com/assets/896246/4465765/4e7b0146-48de-11e4-92ab-d1e43c40d32f.png)
