### PR TITLE
Fixes after last pull and fail-safe for games/channels without image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.project
 /.pydevproject
 *.pyc
+/.idea

--- a/converter.py
+++ b/converter.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from twitch import Keys
-import json
 import xbmcgui, xbmc
 
 class PlaylistConverter(object):
@@ -99,10 +98,9 @@ class JsonListItemConverter(object):
 
     def extractStreamTitleValues(self, stream):
         channel = stream[Keys.CHANNEL]
-        print json.dumps(channel, indent=4, sort_keys=True)
 
         if Keys.VIEWERS in channel:
-            viewers = channel.get(Keys.VIEWERS);
+            viewers = channel.get(Keys.VIEWERS)
         else:
             viewers = stream.get(Keys.VIEWERS, self.plugin.get_string(30062))
 
@@ -122,7 +120,7 @@ class TitleBuilder(object):
         STREAMER_TITLE = u"{streamer} - {title}"
         VIEWERS_STREAMER_TITLE = u"{viewers} - {streamer} - {title}"
         STREAMER_GAME_TITLE = u"{streamer} - {game} - {title}"
-        GAME_VIEWERS_STREAMER_TITLE = u"[{game}] {viewers}|{streamer} - {title}"
+        GAME_VIEWERS_STREAMER_TITLE = u"[{game}] {viewers} | {streamer} - {title}"
         ELLIPSIS = u'...'
 
     def __init__(self, PLUGIN, line_length):
@@ -145,7 +143,7 @@ class TitleBuilder(object):
                    2: TitleBuilder.Templates.TITLE,
                    3: TitleBuilder.Templates.STREAMER,
                    4: TitleBuilder.Templates.STREAMER_GAME_TITLE,
-                   4: TitleBuilder.Templates.GAME_VIEWERS_STREAMER_TITLE}
+                   5: TitleBuilder.Templates.GAME_VIEWERS_STREAMER_TITLE}
         return options.get(titleSetting, TitleBuilder.Templates.STREAMER)
 
     def cleanTitleValue(self, value):
@@ -161,6 +159,4 @@ class TitleBuilder(object):
             shortTitle = title[:self.line_length]
             ending = (title[self.line_length:] and TitleBuilder.Templates.ELLIPSIS)
             return shortTitle + ending
-        else:
-            return title
         return title

--- a/converter.py
+++ b/converter.py
@@ -24,7 +24,12 @@ class JsonListItemConverter(object):
 
     def convertGameToListItem(self, game):
         name = game[Keys.NAME].encode('utf-8')
-        image = game[Keys.BOX].get(Keys.LARGE, '')
+        if not name:
+            name = self.plugin.get_string(30064)
+        try:
+            image = game[Keys.BOX].get(Keys.LARGE, '')
+        except:
+            image = 'http://static-cdn.jtvnw.net/ttv-static/404_boxart.jpg'
         return {'label': name,
                 'path': self.plugin.url_for('createListForGame',
                                             gameName=name, index='0'),

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -44,8 +44,9 @@
   <string id="30048">Stream Title</string>
   <string id="30049">Streamer</string>
   <string id="30051">Streamer - Game Title - Stream Title</string>
+  <string id="30067">Game Title Viewers | Streamer - Stream Title</string>
   <string id="30052">Enable</string>
-  <string id="30053">Password(OAuth Token)</string>
+  <string id="30053">Password (OAuth Token)</string>
 
   <string id="30050">Username</string>
   

--- a/resources/language/Polish/strings.xml
+++ b/resources/language/Polish/strings.xml
@@ -3,6 +3,7 @@
   <!-- main menu -->
   <string id="30001">Gry</string>
   <string id="30002">Śledzeni</string>
+  <string id="30066">Śledzone gry</string>
   <string id="30003">Szukaj</string>
   <string id="30004">Ustawienia</string>
   <string id="30005">Popularne kanały</string>
@@ -43,7 +44,10 @@
   <string id="30048">Tytuł</string>
   <string id="30049">Kanał</string>
   <string id="30051">Kanał - Gra - Tytuł</string>
-  
+  <string id="30067">Gra Liczba oglądających | Kanał - Tytuł</string>
+  <string id="30052">Włączone</string>
+  <string id="30053">Token OAuth</string>
+
   <string id="30050">Użytkownik</string>
 
   <string id="30060">Kanał bez nazwy</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,7 +7,7 @@
 		<!-- Video Quality -->
 		<setting id="video" type="enum" label="30040" lvalues="30041|30042|30043|30044|30063" default="0" />
 		<!-- Title Display -->
-		<setting id="titledisplay" type="enum" label="30045" lvalues="30046|30047|30048|30049|30051" default="0" />
+		<setting id="titledisplay" type="enum" label="30045" lvalues="30046|30047|30048|30049|30051|30067" default="0" />
 		<!-- Truncate titles -->
 		<setting id="titletruncate" type="bool" label="30065" default="true" />
 	</category>


### PR DESCRIPTION
After #129 couple of things should also be added: settings options, translations, etc. There was also title templates array index error (two indices 4). There's also my old fix for channels which may have no image returned from API which is rare but happened to me and broke addon functionality if such channel appeared on any of lists.
So in short, here's my fixes:
- fail-safe fix for games/channels without image
- wrong table index for title templates
- prettify some settings strings
- added Polish translations
- added new template setting to options 
