### PR TITLE
Stream listitem improvements

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -81,7 +81,8 @@ class JsonListItemConverter(object):
         channel = stream[Keys.CHANNEL]
         videobanner = channel.get(Keys.VIDEO_BANNER, '')
         logo = channel.get(Keys.LOGO, '')
-        thumb = "http://static-cdn.jtvnw.net/ttv-boxart/" + urllib.quote(channel.get(Keys.GAME, '')) + "-272x380.jpg"
+        game = channel.get(Keys.GAME, '')
+        thumb = "http://static-cdn.jtvnw.net/ttv-boxart/" + urllib.quote(game) + "-272x380.jpg"
         
         viewers = ''
         if Keys.VIEWERS in channel:
@@ -90,16 +91,13 @@ class JsonListItemConverter(object):
             viewers = stream.get(Keys.VIEWERS, '')
 
         streamer = channel.get(Keys.DISPLAY_NAME, '')
-        game = channel.get(Keys.GAME, '')
 
         title = "[" + str(viewers) + "] " + streamer
-        props = {"fanart_image": videobanner}
         return {'label': title,
-                'path': self.plugin.url_for(endpoint='playLive',
-                                            name=channel[Keys.NAME]),
+                'path': self.plugin.url_for(endpoint='playLive', name=channel[Keys.NAME]),
                 'is_playable': True,
                 'icon': videobanner if videobanner else logo,
-                'properties': props,
+                'properties': {"fanart_image": videobanner if videobanner else logo},
                 'thumbnail': thumb,
                 'info': {
                     'title': title,

--- a/converter.py
+++ b/converter.py
@@ -129,7 +129,11 @@ class TitleBuilder(object):
         template = self.getTitleTemplate(titleSetting)
 
         for key, value in titleValues.iteritems():
-            titleValues[key] = self.cleanTitleValue(value)
+            if key == "game":
+                titleValues[key] = self.cleanTitleValue(value)
+                titleValues[key] = titleValues[key][:5]
+            else:
+                titleValues[key] = self.cleanTitleValue(value)
         title = template.format(**titleValues)
 
         return self.truncateTitle(title)

--- a/converter.py
+++ b/converter.py
@@ -2,7 +2,7 @@
 from twitch import Keys
 import json
 import xbmcgui, xbmc
-import xbmcswift2  # @UnresolvedImport
+import urllib
 
 class PlaylistConverter(object):
     def convertToXBMCPlaylist(self, InputPlaylist):
@@ -81,24 +81,33 @@ class JsonListItemConverter(object):
         channel = stream[Keys.CHANNEL]
         videobanner = channel.get(Keys.VIDEO_BANNER, '')
         logo = channel.get(Keys.LOGO, '')
-
-        path = self.plugin.url_for(endpoint='playLive', name=channel[Keys.NAME])
-        title = self.getTitleForStream(stream)
-        desc = channel.get(Keys.STATUS,
-                                     self.plugin.get_string(30061))
-        game = channel.get(Keys.GAME,
-                                     self.plugin.get_string(30064))
-        icon = videobanner if videobanner else logo
+        thumb = "http://static-cdn.jtvnw.net/ttv-boxart/" + urllib.quote(channel.get(Keys.GAME, '')) + "-272x380.jpg"
+        
+        viewers = ''
         if Keys.VIEWERS in channel:
             viewers = channel.get(Keys.VIEWERS);
         else:
-            viewers = stream.get(Keys.VIEWERS, self.plugin.get_string(30062))
-        artist = channel.get(Keys.DISPLAY_NAME, '')
-        li = xbmcswift2.ListItem(label = '[' + game[:7] + '] ' + artist, icon = icon, thumbnail = icon, path = path)
-        li.set_info('video', { 'plot': desc , 'duration' : game, 'Rating': viewers, 'Tagline' : 'asdasd'})
+            viewers = stream.get(Keys.VIEWERS, '')
 
-        return li
+        streamer = channel.get(Keys.DISPLAY_NAME, '')
+        game = channel.get(Keys.GAME, '')
 
+        title = "[" + str(viewers) + "] " + streamer
+        props = {"fanart_image": videobanner}
+        return {'label': title,
+                'path': self.plugin.url_for(endpoint='playLive',
+                                            name=channel[Keys.NAME]),
+                'is_playable': True,
+                'icon': videobanner if videobanner else logo,
+                'properties': props,
+                'thumbnail': thumb,
+                'info': {
+                    'title': title,
+                    'genre': game,
+                    'votes': viewers,
+                    'plot' : channel.get(Keys.STATUS, '')
+                    }
+                }
 
     def getTitleForStream(self, stream):
         titleValues = self.extractStreamTitleValues(stream)

--- a/converter.py
+++ b/converter.py
@@ -117,6 +117,7 @@ class TitleBuilder(object):
         STREAMER_TITLE = u"{streamer} - {title}"
         VIEWERS_STREAMER_TITLE = u"{viewers} - {streamer} - {title}"
         STREAMER_GAME_TITLE = u"{streamer} - {game} - {title}"
+        GAME_VIEWERS_STREAMER_TITLE = u"[{game}] {viewers} | {streamer} - {title}"
         ELLIPSIS = u'...'
 
     def __init__(self, PLUGIN, line_length):
@@ -138,7 +139,8 @@ class TitleBuilder(object):
                    1: TitleBuilder.Templates.VIEWERS_STREAMER_TITLE,
                    2: TitleBuilder.Templates.TITLE,
                    3: TitleBuilder.Templates.STREAMER,
-                   4: TitleBuilder.Templates.STREAMER_GAME_TITLE}
+                   4: TitleBuilder.Templates.STREAMER_GAME_TITLE,
+                   5: TitleBuilder.Templates.GAME_VIEWERS_STREAMER_TITLE}
         return options.get(titleSetting, TitleBuilder.Templates.STREAMER)
 
     def cleanTitleValue(self, value):

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -44,6 +44,7 @@
   <string id="30048">Stream Title</string>
   <string id="30049">Streamer</string>
   <string id="30051">Streamer - Game Title - Stream Title</string>
+  <string id="40001">Streamer - Viewers - Game Title - Stream Title</string>
   <string id="30052">Enable</string>
   <string id="30053">Password(OAuth Token)</string>
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,7 +7,7 @@
 		<!-- Video Quality -->
 		<setting id="video" type="enum" label="30040" lvalues="30041|30042|30043|30044|30063" default="0" />
 		<!-- Title Display -->
-		<setting id="titledisplay" type="enum" label="30045" lvalues="30046|30047|30048|30049|30051" default="0" />
+		<setting id="titledisplay" type="enum" label="30045" lvalues="30046|30047|30048|30049|30051|40001" default="0" />
 		<!-- Truncate titles -->
 		<setting id="titletruncate" type="bool" label="30065" default="true" />
 	</category>


### PR DESCRIPTION
Removed the custom stream title format and I believe made it better:
Moved the stream videobanner/logo to the fanart tag.
Added stream game poster to thumbnail.
Added stream game title to the genre tag.
Moved the stream status title to the plot tag.
Made stream titles like [viewers] streamer
