### PR TITLE
Disable certificate verification if python 2.7.9+

### DIFF
--- a/resources/lib/twitch/constants.py
+++ b/resources/lib/twitch/constants.py
@@ -86,16 +86,16 @@ class Urls(object):
     SEARCH = BASE + 'search/'
     TEAMS = BASE + 'teams?limit=25&offset={0}'
 
-    TEAMSTREAM = 'http://api.twitch.tv/api/team/{0}/live_channels.json'
-    CHANNEL_TOKEN = 'http://api.twitch.tv/api/channels/{0}/access_token'
-    VOD_TOKEN = 'http://api.twitch.tv/api/vods/{0}/access_token'
+    TEAMSTREAM = 'https://api.twitch.tv/api/team/{0}/live_channels.json'
+    CHANNEL_TOKEN = 'https://api.twitch.tv/api/channels/{0}/access_token'
+    VOD_TOKEN = 'https://api.twitch.tv/api/vods/{0}/access_token'
 
     OPTIONS_OFFSET_LIMIT = '?offset={0}&limit={1}'
     OPTIONS_OFFSET_LIMIT_GAME = OPTIONS_OFFSET_LIMIT + '&game={2}'
     OPTIONS_OFFSET_LIMIT_QUERY = OPTIONS_OFFSET_LIMIT + '&q={2}'
 
-    HLS_PLAYLIST = 'http://usher.twitch.tv/api/channel/hls/{0}.m3u8?sig={1}&token={2}&allow_source=true'
-    VOD_PLAYLIST = 'http://usher.twitch.tv/vod/{0}?nauth={1}&nauthsig={2}&allow_source=true'
+    HLS_PLAYLIST = 'https://usher.twitch.tv/api/channel/hls/{0}.m3u8?sig={1}&token={2}&allow_source=true'
+    VOD_PLAYLIST = 'https://usher.twitch.tv/vod/{0}?nauth={1}&nauthsig={2}&allow_source=true'
 
     CHANNEL_VIDEOS = 'https://api.twitch.tv/kraken/channels/{0}/videos?limit=8&offset={1}&broadcasts={2}'
     VIDEO_PLAYLIST = 'https://api.twitch.tv/api/videos/{0}'

--- a/resources/lib/twitch/utils.py
+++ b/resources/lib/twitch/utils.py
@@ -7,6 +7,12 @@ from urllib2 import Request, urlopen, URLError
 from constants import Keys
 from exception import TwitchException
 
+
+if sys.version_info >= (2, 7, 9):
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
+
+
 MAX_RETRIES = 5
 
 


### PR DESCRIPTION
- update all twitch urls to https scheme
- Disable certificate verification if python 2.7.9+
