### PR TITLE
Use offset/limit for getFollowingStreams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /.project
 /.pydevproject
 *.pyc
+*.pyo
 /.idea

--- a/resources/lib/twitch/api.py
+++ b/resources/lib/twitch/api.py
@@ -47,12 +47,21 @@ class TwitchTV(object):
         channelNames = self._filterChannelNames(followingChannels)
 
         # get Streams of that Channels
+        options = Urls.OPTIONS_OFFSET_LIMIT
+        options += '&channel=' + ','.join([channels[Keys.NAME] for channels in channelNames])
+        rawurl = ''.join([Urls.BASE, Keys.STREAMS, options])
+
         live = []
-        step = 25
-        for i in range(0, len(channelNames), step):
-            options = '?channel=' + ','.join([channels[Keys.NAME] for channels in channelNames[i:i+step]])
-            url = ''.join([Urls.BASE, Keys.STREAMS, options])
-            live += self._fetchItems(url, Keys.STREAMS)
+        limit = 100
+        offset = 0
+        while True:
+            url = rawurl.format(offset, limit)
+            temp = self._fetchItems(url, Keys.STREAMS)
+            if len(temp) == 0:
+                break
+            live += temp
+            offset += limit
+
         channels = {Keys.LIVE: live, Keys.OTHERS: channelNames}
         return channels
 


### PR DESCRIPTION
Splitting the array breaks the order of the streams, which are returned from the API ordered by the number of viewers.
This uses the default offset/limit approach instead, raising the limit to the maximum possible 100.

Also adds *.pyo to gitignore, as that's what Kodi creates.
