### PR TITLE
update for upcoming Client ID requirement

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
-    <!-- Next available: 30096 -->
+    <!-- Next available: 30098 -->
     <!-- main menu -->
     <string id="30001">Games</string>
     <string id="30002">Following</string>
@@ -70,6 +70,8 @@
     <string id="30086">These settings may allow this add-on to delete database entries and images[CR]for cached live previews.</string>
     <string id="30087">Notifications</string>
     <string id="30094">Automatic refresh interval (minutes)</string>
+    <string id="30096">API</string>
+    <string id="30097">OAuth Client ID</string>
 
     <string id="30050">Username</string>
 

--- a/resources/lib/twitch/constants.py
+++ b/resources/lib/twitch/constants.py
@@ -70,9 +70,7 @@ class Keys(object):
     USER_AGENT_STRING = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:6.0) Gecko/20100101 Firefox/6.0'
     API_VERSION = 'application/vnd.twitchtv.v{0}+json'.format(str(TWITCH_API_VERSION))
     CLIENT_ID_HEADER = 'Client-ID'
-    CLIENT_ID = 'TwitchonXBMC_{0}'
-    DEFAULT_ID = 'user_{0}'
-
+    CLIENT_ID = ''  # base64 encoded Client ID
 
 class Urls(object):
     '''

--- a/resources/lib/twitch/utils.py
+++ b/resources/lib/twitch/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 import json
-from random import randint
+from base64 import b64decode
 from xbmcaddon import Addon
 from urllib2 import Request, urlopen, URLError
 from constants import Keys
@@ -65,11 +65,13 @@ class JSONScraper(object):
 
     def getJson(self, url, headers=None):
         def getClientID():
-            # return a Client-ID to use for Twitch API: TwitchonXBMC_<username|'user_'randint(1000,2000)>
-            username = self.__get_current_username()
-            if not username:
-                username = Keys.DEFAULT_ID.format(str(randint(1000, 2000)))
-            client_id = Keys.CLIENT_ID.format(username)
+            # return a Client ID to use for Twitch API
+            client_id = Addon().getSetting('oauth_client_id')  # get from settings
+            if not client_id:  # not in settings
+                try:
+                    client_id = b64decode(Keys.CLIENT_ID)  # use Keys.CLIENT_ID
+                except:
+                    client_id = ''
             return client_id
 
         if not headers:
@@ -85,10 +87,6 @@ class JSONScraper(object):
             return jsonDict
         except:
             raise TwitchException(TwitchException.JSON_ERROR)
-
-    @staticmethod
-    def __get_current_username():
-        return Addon().getSetting('username').lower()
 
 
 class M3UPlaylist(object):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -45,4 +45,9 @@
         <setting label="30075" id="install_ircscript" type="action" action="RunPlugin(plugin://script.ircchat/)"
                  enable="!System.HasAddon(script.ircchat)" visible="!System.HasAddon(script.ircchat)"/>
     </category>
+    <!-- API -->
+    <category label="30096">
+        <!-- OAUTH Client ID -->
+        <setting id="oauth_client_id" type="text" label="30097" default=""/>
+    </category>
 </settings>


### PR DESCRIPTION
- default Client ID currently empty, to be filled by project maintainers @ [twitch][constants] Keys.CLIENT_ID
- add 'API' - 'OAuth Client ID' to settings (allow users to provide their own)
- settings based Client ID has precedence

Regarding Issue: #164
