### PR TITLE
Fix a policy violation and stylization

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
-    <!-- Next available: 30099 -->
+    <!-- Next available: 30100 -->
     <!-- main menu -->
     <string id="30001">Games</string>
     <string id="30002">Following</string>
@@ -75,7 +75,7 @@
     <string id="30097">OAuth Client ID</string>
 
     <string id="30050">Username</string>
-    <string id="31230">Oauth Token</string>
+    <string id="30099">OAuth Token</string>
 
     <!--contextmenu-->
     <string id="30077">Play (Choose Quality)</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,8 +4,8 @@
     <category label="30076">
         <!-- Username -->
         <setting id="username" type="text" label="30050" default=""/>
-        <!-- Oauth Token -->
-        <setting id="oauth_token" type="text" label="31230" default=""/>
+        <!-- OAuth Token -->
+        <setting id="oauth_token" type="text" label="30099" default=""/>
         <!-- Video Quality -->
         <setting id="video" type="enum" label="30040" lvalues="30041|30042|30043|30044|30063" default="0"/>
         <!-- Title Display -->


### PR DESCRIPTION
since c5169772af7, this addon violates a policy outlined in
http://kodi.wiki/view/Language_support#String_ID_range, specifically
that stringid 31000 thru 31999 are reserved for skins, not addons.

Also this commit changes the stylizing of OAuth to be in consistent
across the addon
