### PR TITLE
Updates/Fixes

### DIFF
--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -32,11 +32,7 @@
   
   <!--settings -->
   <string id="30040">Video kvalita</string>
-  <string id="30041">Nejlepší</string>
-  <string id="30042">720p</string>
-  <string id="30043">480p</string>
-  <string id="30044">360p</string>
-  <string id="30063">226p (mobilní)</string>
+
   <string id="30045">Zobrazení titulku</string>
   <string id="30046">Streamer - Název streamu</string>
   <string id="30047">Sledující - Streamer - Název streamu</string>

--- a/resources/language/Danish/strings.xml
+++ b/resources/language/Danish/strings.xml
@@ -33,11 +33,7 @@
   
   <!--settings -->
   <string id="30040">Video Kvalitet</string>
-  <string id="30041">Bedst mulige</string>
-  <string id="30042">720p</string>
-  <string id="30043">480p</string>
-  <string id="30044">360p</string>
-  <string id="30063">226p (Mobil)</string>
+
   <string id="30045">Vis titler</string>
   <string id="30046">Streamer - Stream Titel</string>
   <string id="30047">Seere - Streamer - Stream Titel</string>

--- a/resources/language/Dutch/strings.xml
+++ b/resources/language/Dutch/strings.xml
@@ -32,11 +32,7 @@
   
   <!--settings -->
   <string id="30040">Beeldkwaliteit</string>
-  <string id="30041">Beste mogelijk</string>
-  <string id="30042">720p</string>
-  <string id="30043">480p</string>
-  <string id="30044">360p</string>
-  <string id="30063">226p (Mobile)</string>
+
   <string id="30045">Titels weergeven</string>
   <string id="30046">Streamer - Stream Titel</string>
   <string id="30047">Kijkers - Streamer - Stream Titel</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
-    <!-- Next available: 30102 -->
+    <!-- Next available: 30041-30044, 30063, 30113 -->
     <!-- main menu -->
     <string id="30001">Games</string>
     <string id="30002">Following</string>
@@ -40,11 +40,7 @@
 
     <!--settings -->
     <string id="30040">Video Quality</string>
-    <string id="30041">Best possible</string>
-    <string id="30042">720p</string>
-    <string id="30043">480p</string>
-    <string id="30044">360p</string>
-    <string id="30063">226p (Mobile)</string>
+
     <string id="30045">Display titles</string>
     <string id="30046">Streamer - Stream Title</string>
     <string id="30047">Viewers - Streamer - Stream Title</string>
@@ -78,6 +74,18 @@
     <string id="30099">OAuth Token</string>
     <string id="30100">Visit www.twitch.tv/settings/connections and [CR]'Register your application' for an OAuth Client-ID</string>
     <string id="30101">Visit www.twitchapps.com/tmi to generate an OAuth token</string>
+
+    <string id="30102">Source</string>
+    <string id="30103">1080p60</string>
+    <string id="30104">1080p30</string>
+    <string id="30105">720p60</string>
+    <string id="30106">720p30</string>
+    <string id="30107">540p30</string>
+    <string id="30108">480p30</string>
+    <string id="30109">360p30</string>
+    <string id="30110">240p30</string>
+    <string id="30111">144p30</string>
+    <string id="30112">Quality may result in best match</string>
 
     <!--contextmenu-->
     <string id="30077">Play (Choose Quality)</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
-    <!-- Next available: 30100 -->
+    <!-- Next available: 30102 -->
     <!-- main menu -->
     <string id="30001">Games</string>
     <string id="30002">Following</string>
@@ -76,6 +76,8 @@
 
     <string id="30050">Username</string>
     <string id="30099">OAuth Token</string>
+    <string id="30100">Visit www.twitch.tv/settings/connections and [CR]'Register your application' for an OAuth Client-ID</string>
+    <string id="30101">Visit www.twitchapps.com/tmi to generate an OAuth token</string>
 
     <!--contextmenu-->
     <string id="30077">Play (Choose Quality)</string>

--- a/resources/language/French/strings.xml
+++ b/resources/language/French/strings.xml
@@ -39,11 +39,7 @@
 
     <!--settings -->
     <string id="30040">Qualité vidéo</string>
-    <string id="30041">Meilleur</string>
-    <string id="30042">720p</string>
-    <string id="30043">480p</string>
-    <string id="30044">360p</string>
-    <string id="30063">226p (Mobile)</string>
+
     <string id="30045">Afficher le titre</string>
     <string id="30046">Chaine - Titre</string>
     <string id="30047">Spectateur - Chaine - Titre</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -34,11 +34,7 @@
   
     <!--settings -->
   <string id="30040">Video-Qualität</string>
-  <string id="30041">Bestmöglich</string>
-  <string id="30042">720p</string>
-  <string id="30043">480p</string>
-  <string id="30044">360p</string>
-  <string id="30063">226p (Mobil)</string>
+
   <string id="30045">Zeige Stream-Namen</string>
   <string id="30046">Streamer - Stream-Name</string>
   <string id="30047">Zuschauer - Streamer - Stream-Name</string>

--- a/resources/language/Norwegian/strings.xml
+++ b/resources/language/Norwegian/strings.xml
@@ -39,11 +39,7 @@
   
   <!--settings -->
   <string id="30040">Videokvalitet</string>
-  <string id="30041">Best mulig</string>
-  <string id="30042">720p</string>
-  <string id="30043">480p</string>
-  <string id="30044">360p</string>
-  <string id="30063">226p (Mobil)</string>
+
   <string id="30045">Vis titler</string>
   <string id="30046">Strømmer - Stream Tittel</string>
   <string id="30047">Seere - Strømmer - Tittel til strøm</string>

--- a/resources/language/Polish/strings.xml
+++ b/resources/language/Polish/strings.xml
@@ -40,11 +40,7 @@
 
     <!--settings -->
     <string id="30040">Jakość video</string>
-    <string id="30041">Najlepsza możliwa</string>
-    <string id="30042">720p</string>
-    <string id="30043">480p</string>
-    <string id="30044">360p</string>
-    <string id="30063">226p (Mobile)</string>
+
     <string id="30045">Schemat wyświetlania tytułów</string>
     <string id="30046">Kanał - Tytuł</string>
     <string id="30047">Liczba oglądających - Kanał - Tytuł</string>

--- a/resources/language/Spanish/strings.xml
+++ b/resources/language/Spanish/strings.xml
@@ -28,11 +28,7 @@
 <string id="30029">Por favor, comprueba tu conexión a Internet</string>
 <!--settings -->
 <string id="30040">Calidad de vídeo</string>
-<string id="30041">La mejor posible</string>
-<string id="30042">720p</string>
-<string id="30043">480p</string>
-<string id="30044">360p</string>
-<string id="30063">226p (Móvil)</string>
+
 <string id="30045">Mostrar títulos</string>
 <string id="30046">Streamer - Título del Stream </string>
 <string id="30047">Espectadores - Streamer - Título del Stream</string>

--- a/resources/lib/converter.py
+++ b/resources/lib/converter.py
@@ -217,7 +217,15 @@ class JsonListItemConverter(object):
         def formatKey(thisKey):
             value = ''
             if info.get(thisKey) is not None:
-                value = item_template.format(head=headings.get(thisKey), info=info.get(thisKey))
+                try:
+                    val_heading = headings.get(thisKey).encode('utf-8', 'ignore')
+                except:
+                    val_heading = headings.get(thisKey)
+                try:
+                    val_info = info.get(thisKey).encode('utf-8', 'ignore')
+                except:
+                    val_info = info.get(thisKey)
+                value = item_template.format(head=val_heading, info=val_info)
             return value
 
         plot = plot_template.format(title=title, game=formatKey(Keys.GAME),

--- a/resources/lib/routes.py
+++ b/resources/lib/routes.py
@@ -196,16 +196,16 @@ def channelVideosList(name, index, past):
 @managedTwitchExceptions
 def createListForSelectedVideo():
     def extractVideoID(url):
-        _id = url                         # http://twitch.tv/a/v/12345678?t=9m1s
+        _id = url  # http://twitch.tv/a/v/12345678?t=9m1s
         idx = _id.find('?')
         if idx >= 0:
-            _id = _id[:idx]               # https://twitch.tv/a/v/12345678
+            _id = _id[:idx]  # https://twitch.tv/a/v/12345678
         idx = _id.rfind('/')
         if idx >= 0:
-            _id = _id[:idx] + _id[idx+1:] # https://twitch.tv/a/v12345678
+            _id = _id[:idx] + _id[idx + 1:]  # https://twitch.tv/a/v12345678
         idx = _id.rfind('/')
         if idx >= 0:
-            _id = _id[idx+1:]             # v12345678
+            _id = _id[idx + 1:]  # v12345678
         return _id
 
     items = []
@@ -225,8 +225,7 @@ def playVideo(_id, quality):
     """
     :param _id: string: video id
     :param quality: string: qualities[quality]
-    qualities = {'-1': -1, '0': 0, '1': 1, '2': 2, '3': 3, '4': 4}
-    0 = Best, 1 = 720, 2 = 480, 3 = 360, 4 = 226,
+    0 = Source, 1 = 1080p60, 2 = 1080p30, 3 = 720p60, 4 = 720p30, 5 = 540p30, 6 = 480p30, 7 = 360p30, 8 = 240p30, 9 = 144p30
     -1 = Choose quality dialog
     * any other value for quality will use addon setting
     """
@@ -244,10 +243,12 @@ def playVideo(_id, quality):
         else:
             raise TwitchException(TwitchException.NO_PLAYABLE)
 
+
 @PLUGIN.route('/playVideo/<_id>/')
 @managedTwitchExceptions
 def oldplayVideo(_id):
-    playVideo(_id, 5)
+    playVideo(_id, -2)
+
 
 @PLUGIN.route('/search/')
 @managedTwitchExceptions
@@ -283,8 +284,7 @@ def playLive(name, quality):
     """
     :param name: string: stream/channel name
     :param quality: string: qualities[quality]
-    qualities = {'-1': -1, '0': 0, '1': 1, '2': 2, '3': 3, '4': 4}
-    0 = Best, 1 = 720, 2 = 480, 3 = 360, 4 = 226,
+    0 = Source, 1 = 1080p60, 2 = 1080p30, 3 = 720p60, 4 = 720p30, 5 = 540p30, 6 = 480p30, 7 = 360p30, 8 = 240p30, 9 = 144p30
     -1 = Choose quality dialog
     * any other value for quality will use addon setting
     """
@@ -296,10 +296,12 @@ def playLive(name, quality):
         utils.play(stream['path'], stream)
         utils.execIrcPlugin(name)
 
+
 @PLUGIN.route('/playLive/<name>/')
 @managedTwitchExceptions
 def oldplayLive(name):
-    playLive(name, 5)
+    playLive(name, -2)
+
 
 @PLUGIN.route('/createListOfTeams/<index>/')
 @managedTwitchExceptions

--- a/resources/lib/twitch/api.py
+++ b/resources/lib/twitch/api.py
@@ -139,7 +139,11 @@ class TwitchTV(object):
             access_token[Keys.TOKEN],
             access_token[Keys.SIG])
         playlistQualitiesData = self.scraper.downloadWebData(playlistQualitiesUrl)
-        playlistQualities = M3UPlaylist(playlistQualitiesData)
+
+        qualityList = Keys.QUALITY_LIST_STREAM
+        if 'NAME="360p30"' not in playlistQualitiesData:
+            qualityList = Keys.OLD_QUALITY_LIST_STREAM
+        playlistQualities = M3UPlaylist(playlistQualitiesData, qualityList)
 
         vodUrl = playlistQualities.getQuality(maxQuality)
         playlist += [(vodUrl, ())]
@@ -194,7 +198,10 @@ class TwitchTV(object):
         try:
             hls_url = Urls.HLS_PLAYLIST.format(channelName, channelsig, channeltoken)
             data = self.scraper.downloadWebData(hls_url)
-            playlist = M3UPlaylist(data)
+            qualityList = Keys.QUALITY_LIST_STREAM
+            if 'NAME="360p30"' not in data:
+                qualityList = Keys.OLD_QUALITY_LIST_STREAM
+            playlist = M3UPlaylist(data, qualityList)
             return playlist.getQuality(maxQuality)
 
         except TwitchException:

--- a/resources/lib/twitch/constants.py
+++ b/resources/lib/twitch/constants.py
@@ -70,7 +70,7 @@ class Keys(object):
     USER_AGENT_STRING = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:6.0) Gecko/20100101 Firefox/6.0'
     API_VERSION = 'application/vnd.twitchtv.v{0}+json'.format(str(TWITCH_API_VERSION))
     CLIENT_ID_HEADER = 'Client-ID'
-    CLIENT_ID = ''  # base64 encoded Client ID
+    CLIENT_ID = 'NjdlYnBmaHlvaWNhYjVrcjB5N3B6b2NzZm9oczd0eQ=='
 
 class Urls(object):
     '''

--- a/resources/lib/twitch/constants.py
+++ b/resources/lib/twitch/constants.py
@@ -61,8 +61,12 @@ class Keys(object):
     DESCRIPTION = 'description'
     CREATED_AT = 'created_at'
 
-    QUALITY_LIST_STREAM = ['Source', '1080p60', '1080p30', '720p60','720p30','540p30','480p30','360p30','240p30','144p30', 'High', 'Medium', 'Low', 'Mobile']
-    QUALITY_LIST_VIDEO = ['live', '1080p60', '1080p30', '720p60','720p30','540p30','480p30','360p30','240p30','144p30', '720p', '480p', '360p', '226p']
+    OLD_QUALITY_LIST_STREAM = ['Source', 'High', 'Medium', 'Low', 'Mobile']
+    OLD_QUALITY_LIST_VIDEO = ['live', '720p', '480p', '360p', '226p']
+    QUALITY_LIST_STREAM = ['Source', '1080p60', '1080p30', '720p60', '720p30', '540p30', '480p30', '360p30', '240p30',
+                           '144p30']
+    QUALITY_LIST_VIDEO = ['live', '1080p60', '1080p30', '720p60', '720p30', '540p30', '480p30', '360p30', '240p30',
+                          '144p30']
 
     ACCEPT = 'Accept'
     REFERER = 'Referer'
@@ -71,6 +75,7 @@ class Keys(object):
     API_VERSION = 'application/vnd.twitchtv.v{0}+json'.format(str(TWITCH_API_VERSION))
     CLIENT_ID_HEADER = 'Client-ID'
     CLIENT_ID = 'NjdlYnBmaHlvaWNhYjVrcjB5N3B6b2NzZm9oczd0eQ=='
+
 
 class Urls(object):
     '''

--- a/resources/lib/twitch/utils.py
+++ b/resources/lib/twitch/utils.py
@@ -97,7 +97,7 @@ class M3UPlaylist(object):
         lines = data.splitlines()
         linesIterator = iter(lines)
         for line in linesIterator:
-            if line.startswith('#EXT-X-MEDIA'):
+            if line.startswith('#EXT-X-MEDIA:TYPE=VIDEO'):
                 quality, url = parseQuality(line, next(linesIterator), next(linesIterator))
                 qualityInt = self.qualityList.index(quality)
                 self.playlist[qualityInt] = url

--- a/resources/lib/twitch/utils.py
+++ b/resources/lib/twitch/utils.py
@@ -32,7 +32,7 @@ class JSONScraper(object):
                 if headers:
                     headers[Keys.USER_AGENT] = Keys.USER_AGENT_STRING
                 else:
-                    headers = { Keys.USER_AGENT: Keys.USER_AGENT_STRING }
+                    headers = {Keys.USER_AGENT: Keys.USER_AGENT_STRING}
 
                 response = requests.get(url, headers=headers, verify=False)
                 data = response.content
@@ -107,13 +107,27 @@ class M3UPlaylist(object):
 
     # returns selected quality or best match if not available
     def getQuality(self, selectedQuality):
-        if selectedQuality in self.playlist.keys():
+        bestDistance = len(self.qualityList) + 1
+
+        if (selectedQuality in self.playlist.keys()) and (bestDistance == len(Keys.QUALITY_LIST_STREAM) + 1):
             # selected quality is available
             return self.playlist[selectedQuality]
         else:
             # not available, calculate differences to available qualities
             # return lowest difference / lower quality if same distance
             bestDistance = len(self.qualityList) + 1
+            # if not using standard list, adjust selected quality to appropriate old quality
+            if bestDistance != len(Keys.QUALITY_LIST_STREAM) + 1:
+                if selectedQuality <= 2:
+                    selectedQuality = 0
+                elif selectedQuality <= 4:
+                    selectedQuality = 1
+                elif selectedQuality <= 6:
+                    selectedQuality = 2
+                elif selectedQuality <= 7:
+                    selectedQuality = 3
+                else:
+                    selectedQuality = 4
             bestMatch = None
 
             for quality in sorted(self.playlist, reverse=True):

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -41,17 +41,19 @@ def getVideoQuality(quality=''):
     """
     :param quality: string int/int: qualities[quality]
     qualities
-    0 = Best, 1 = 720, 2 = 480, 3 = 360, 4 = 226,
+    0 = Source, 1 = 1080p60, 2 = 1080p30, 3 = 720p60, 4 = 720p30, 5 = 540p30, 6 = 480p30, 7 = 360p30, 8 = 240p30, 9 = 144p30
     -1 = Choose quality dialog
     * any other value for quality will use addon setting
-    i18n: 0 = 30041, 1 = 30042, 2 = 30043, 3 = 30044, 4 = 30063
+    i18n: 0 = 30102 ... 9 = 30111
     """
-    qualities = {'-1': -1, '0': 0, '1': 1, '2': 2, '3': 3, '4': 4}
-    i18n_qualities = [PLUGIN.get_string(30041), PLUGIN.get_string(30042), PLUGIN.get_string(30043),
-                      PLUGIN.get_string(30044), PLUGIN.get_string(30063)]
+    qualities = {'-1': -1, '0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9 }
+    i18n_qualities = [PLUGIN.get_string(30102), PLUGIN.get_string(30103), PLUGIN.get_string(30104),
+                      PLUGIN.get_string(30105), PLUGIN.get_string(30106), PLUGIN.get_string(30107),
+                      PLUGIN.get_string(30108), PLUGIN.get_string(30109), PLUGIN.get_string(30110),
+                      PLUGIN.get_string(30111)]
     try:
         quality = int(quality)
-        if 4 >= quality >= 0:
+        if 9 >= quality >= 0:
             chosenQuality = str(quality)
         elif quality == -1:
             chosenQuality = str(xbmcgui.Dialog().select(PLUGIN.get_string(30077), i18n_qualities))

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -21,13 +21,21 @@ def getUserName():
         PLUGIN.open_settings()
         username = PLUGIN.get_setting('username', unicode).lower()
     return username
-    
-def getOauthToken():
+
+
+def getOauthToken(token_only=True):
     oauthtoken = PLUGIN.get_setting('oauth_token', unicode)
     if not oauthtoken:
         PLUGIN.open_settings()
         oauthtoken = PLUGIN.get_setting('oauth_token', unicode)
+    if oauthtoken:
+        if token_only:
+            oauthtoken = oauthtoken.replace('oauth:', '')
+        else:
+            if not oauthtoken.lower().startswith('oauth:'):
+                oauthtoken = 'oauth:{0}'.format(oauthtoken)
     return oauthtoken
+
 
 def getVideoQuality(quality=''):
     """
@@ -102,7 +110,7 @@ def execIrcPlugin(channel):
     if PLUGIN.get_setting('irc_enable', unicode) != 'true':
         return
     uname = PLUGIN.get_setting('irc_username', unicode)
-    passwd = PLUGIN.get_setting('oauth_token', unicode)
+    passwd = getOauthToken(token_only=False)
     host = 'irc.chat.twitch.tv'
     scrline = 'RunScript(script.ircchat, run_irc=True&nickname=%s&username=%s&password=%s&host=%s&channel=#%s)' % \
               (uname, uname, passwd, host, channel)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,7 +8,9 @@
         <setting id="oauth_token" type="text" label="30099" default=""/>
         <setting label="30101" type="lsep"/>
         <!-- Video Quality -->
-        <setting id="video" type="enum" label="30040" lvalues="30041|30042|30043|30044|30063" default="0"/>
+        <setting id="video" type="enum" label="30040"
+                 lvalues="30102|30103|30104|30105|30106|30107|30108|30109|30110|30111" default="3"/>
+        <setting label="30112" type="lsep"/>
         <!-- Title Display -->
         <setting id="titledisplay" type="enum" label="30045" lvalues="30046|30047|30048|30049|30051|30067" default="0"/>
         <!-- Truncate titles -->

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,6 +6,7 @@
         <setting id="username" type="text" label="30050" default=""/>
         <!-- OAuth Token -->
         <setting id="oauth_token" type="text" label="30099" default=""/>
+        <setting label="30101" type="lsep"/>
         <!-- Video Quality -->
         <setting id="video" type="enum" label="30040" lvalues="30041|30042|30043|30044|30063" default="0"/>
         <!-- Title Display -->
@@ -43,13 +44,15 @@
         <!-- Username -->
         <setting id="irc_username" type="text" label="30050" default="" enable="eq(-1,true)"/>
         <!-- OAuth Token -->
-        <setting id="oauth_token" type="text" option="hidden" label="30053" default="67ebpfhyoicab5kr0y7pzocsfohs7tyaa" enable="eq(-2,true)"/>
+        <setting id="oauth_token" type="text" label="30053" default="" enable="eq(-2,true)"/>
+        <setting label="30101" type="lsep"/>
         <setting label="30075" id="install_ircscript" type="action" action="RunPlugin(plugin://script.ircchat/)"
                  enable="!System.HasAddon(script.ircchat)" visible="!System.HasAddon(script.ircchat)"/>
     </category>
     <!-- API -->
     <category label="30096">
         <!-- OAUTH Client ID -->
-        <setting id="oauth_client_id" type="text" label="30097" default="67ebpfhyoicab5kr0y7pzocsfohs7ty"/>
+        <setting id="oauth_client_id" type="text" label="30097" default=""/>
+        <setting label="30100" type="lsep"/>
     </category>
 </settings>


### PR DESCRIPTION
oauth
- default client-id b64encoded
- add/remove 'oauth:' pre-append for oauth token
- add information to settings to inform user on where to start for token/id generation

Resolve error introduced by closed caption addition

qualities
- update to new quality settings
- add best match notice to quality in settings
- add to best match logic, new qualities map to old qualities on a best match basis if stream does not have new qualities available (currently ~99% of streams don't use these yet)

plotForStream
- try utf-8 encoding all headers and info before appending to plot, ignoring errors

This should close #188 #187 and #183 in way of quality selection
