### PR TITLE
Handle new resolution strings for uploaded videos.

### DIFF
--- a/resources/lib/twitch/api.py
+++ b/resources/lib/twitch/api.py
@@ -141,7 +141,7 @@ class TwitchTV(object):
         playlistQualitiesData = self.scraper.downloadWebData(playlistQualitiesUrl)
 
         qualityList = Keys.QUALITY_LIST_STREAM
-        if 'NAME="360p30"' not in playlistQualitiesData:
+        if 'NAME="360p30"' not in playlistQualitiesData and 'NAME="360p"' not in playlistQualitiesData:
             qualityList = Keys.OLD_QUALITY_LIST_STREAM
         playlistQualities = M3UPlaylist(playlistQualitiesData, qualityList)
 

--- a/resources/lib/twitch/constants.py
+++ b/resources/lib/twitch/constants.py
@@ -63,8 +63,8 @@ class Keys(object):
 
     OLD_QUALITY_LIST_STREAM = ['Source', 'High', 'Medium', 'Low', 'Mobile']
     OLD_QUALITY_LIST_VIDEO = ['live', '720p', '480p', '360p', '226p']
-    QUALITY_LIST_STREAM = ['Source', '1080p60 - source', '1080p60', '1080p30', '720p60', '720p30 - source', '720p30', '540p30', 
-                          '480p30', '360p30', '240p30','144p30']
+    QUALITY_LIST_STREAM = ['Source', '1080p60 - source', '1080p60', '1080p30', '1080p', '720p60', '720p30 - source', '720p30', '720p',
+                          '540p30', '540p', '480p30', '480p', '360p30', '360p', '240p30', '240p', '144p30', '144p']
     QUALITY_LIST_VIDEO = ['live', '1080p60 - source', '1080p60', '1080p30', '720p30 - source', '720p60', '720p30', '540p30', 
                          '480p30', '360p30', '240p30','144p30']
 


### PR DESCRIPTION
Handle 1080p, 720p, 480p, 360p, 240p, 144p resolution strings for
Twitch's new video upload service.

Trying to stream an uploaded video (referenced via id) caused an exception "ValueError: u'1080p' is not in list".  I've added the additional resolution strings in constants.py and handled looking for "360p" in addition to "360p30" in the twitch api.py file.
