### PR TITLE
prevent None from slipping through in _fetchItems()

### DIFF
--- a/resources/lib/twitch/api.py
+++ b/resources/lib/twitch/api.py
@@ -220,4 +220,4 @@ class TwitchTV(object):
 
     def _fetchItems(self, url, key):
         items = self.scraper.getJson(url)
-        return items[key] if items else []
+        return items[key] if items and items[key] else []


### PR DESCRIPTION
check that a key does not only exist in an API response, but is also set to something more than `null`