### PR TITLE
move en_gb summary, and description to first

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -25,12 +25,12 @@
         <source>https://github.com/MrSprigster/Twitch-on-Kodi</source>
         <license>GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007</license>
         <forum>http://forum.kodi.tv/showthread.php?tid=134538</forum>
+        <summary lang='en_GB'>Twitch video plugin</summary>
+        <description lang='en_GB'>Watch your favorite gaming streams!</description>
         <summary lang='da_DK'>Twitch video plugin</summary>
         <description lang='da_DK'>Se dine favorit gaming streams!</description>
         <summary lang='de_DE'>Twitch video plugin</summary>
         <description lang='de_DE'>Schaue die besten Gaming-Streams!</description>
-        <summary lang='en_GB'>Twitch video plugin</summary>
-        <description lang='en_GB'>Watch your favorite gaming streams!</description>
         <summary lang='es_ES'>Twitch video plugin</summary>
         <description lang='es_ES'>¡Mira los streams de tus juegos favoritos!</description>
         <summary lang='fr_FR'>Twitch video plugin</summary>


### PR DESCRIPTION
- the Kodi showcase appears to pull the en_gb summary but the first description