### PR TITLE
pass window to the player - fixes class attribute leak

### DIFF
--- a/resources/lib/twitch_addon/addon/player.py
+++ b/resources/lib/twitch_addon/addon/player.py
@@ -23,7 +23,6 @@ converter = JsonListItemConverter(LINE_LENGTH)
 
 
 class TwitchPlayer(xbmc.Player):
-    window = kodi.Window(10000)
     player_keys = {
         'twitch_playing': ID + '-twitch_playing'
     }
@@ -34,8 +33,12 @@ class TwitchPlayer(xbmc.Player):
         'stream': ID + '-livestream'
     }
 
-    def __init__(self, *args, **kwargs):
+    def __new__(cls, window, *args, **kwargs):
+        return super(TwitchPlayer, cls).__new__(cls, *args, **kwargs)
+
+    def __init__(self, window, *args, **kwargs):
         log_utils.log('Player: Start', log_utils.LOGDEBUG)
+        self.window = window
         self.reset()
 
     def reset(self):

--- a/resources/lib/twitch_addon/service.py
+++ b/resources/lib/twitch_addon/service.py
@@ -53,7 +53,7 @@ class LiveNotificationsThread(threading.Thread):
         abort = False
         first_run = True
 
-        player = TwitchPlayer()
+        player = TwitchPlayer(window)
 
         while not monitor.abortRequested() and not self.stopped():
             time_diff = get_stamp_diff(timestamp)


### PR DESCRIPTION
log when leaking:
  WARNING: CPythonInvoker(1, /home/kodi/.kodi/addons/plugin.video.twitch/resources/lib/service_runner.py): the python script "/home/kodi/.kodi/addons/plugin.video.twitch/resources/lib/service_runner.py" has left several classes in memory that we couldn't clean up. The classes include: N9XBMCAddon7xbmcgui6WindowE

@anxdpanic: I'm not absolutely sure of the window usage in this pr, please discard if I'm wrong and can't reuse the service window.