### PR TITLE
Drop left over line which was used to show reruns

### DIFF
--- a/resources/lib/twitch_addon/routes/followed.py
+++ b/resources/lib/twitch_addon/routes/followed.py
@@ -25,7 +25,6 @@ def route(api, content, after='MA=='):
     per_page = utils.get_items_per_page()
     if content == StreamType.LIVE or content == StreamType.PLAYLIST:
         if content == StreamType.LIVE:
-            content = StreamType.ALL
             utils.refresh_previews()
         kodi.set_view('videos', set_sort=True)
 


### PR DESCRIPTION
I just ran into #514 and thanks to @Psychoses I found directly where to look for the issue.

Instead of replacing "content" in the link_to_next_page call, I had a look where this issue actually comes from.

Actually "content" comes in as "StreamType.LIVE" but then gets replaced here:
https://github.com/anxdpanic/plugin.video.twitch/blob/44d0aa6b39d1297eeb2c827694471bddd609dab5/resources/lib/twitch_addon/routes/followed.py#L28

When checking where this line came from, this brings me to this commit:
https://github.com/anxdpanic/plugin.video.twitch/commit/f696fdb3008f10d395562e0e2049b14632b22e04

And checking how the file looked like back then reveals that "content" once was used in the actual API call:
https://github.com/anxdpanic/plugin.video.twitch/blob/f696fdb3008f10d395562e0e2049b14632b22e04/resources/lib/twitch_addon/routes/followed.py#L41

But this is no longer the case and the leftover "content" replace, which once was added to show reruns, now causes issues with the "Next page..." entry.

After deleting this line (what my pull request does) I can verify that navigation to the next page works as expected. The only ugly effect, I still have, is that I also get the "Next page..." entry if I have exactly 25 live streams which then pops up a message that there are no additional items. But I would open a new Issue for this as soon as my PR is merged.