### PR TITLE
Restore functionality of "Following Channels"

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.twitch" version="3.0.1" name="Twitch" provider-name="anxdpanic, A Talented Community">
+<addon id="plugin.video.twitch" version="3.0.2" name="Twitch" provider-name="anxdpanic, A Talented Community">
     <requires>
         <import addon="xbmc.python" version="3.0.1"/>
         <import addon="script.module.requests" version="2.9.1"/>
-        <import addon="script.module.python.twitch" version="3.0.0"/>
+        <import addon="script.module.python.twitch" version="3.0.2"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="resources/lib/addon_runner.py">
         <provides>video</provides>
@@ -15,7 +15,7 @@
             <fanart>resources/media/fanart.jpg</fanart>
         </assets>
         <news>
-[rem] toggle follow
+[fix] Following Channels
 [lang] updated translations from Weblate
         </news>
         <platform>all</platform>

--- a/resources/lib/twitch_addon/addon/api.py
+++ b/resources/lib/twitch_addon/addon/api.py
@@ -187,8 +187,8 @@ class Twitch:
 
     @api_error_handler
     @cache.cache_method(cache_limit=cache.limit)
-    def get_followed_channels(self, from_id='', to_id='', after='MA==', before='MA==', first=20):
-        results = self.api.users.get_follows(from_id=from_id, to_id=to_id, after=after, before=before, first=first)
+    def get_followed_channels(self, user_id='', after='MA==', first=20):
+        results = self.api.users.get_follows(user_id=user_id, after=after, first=first)
         return self.error_check(results)
 
     @api_error_handler

--- a/resources/lib/twitch_addon/routes/followed.py
+++ b/resources/lib/twitch_addon/routes/followed.py
@@ -68,11 +68,11 @@ def route(api, content, after='MA=='):
         all_items = list()
         followed_ids = list()
 
-        followed = api.get_followed_channels(from_id=user_id, after=after, first=per_page)
+        followed = api.get_followed_channels(user_id=user_id, after=after, first=per_page)
         if Keys.DATA in followed:
             for follow in followed[Keys.DATA]:
-                if follow.get(Keys.TO_ID):
-                    followed_ids.append(follow[Keys.TO_ID])
+                if follow.get(Keys.BROADCASTER_ID):
+                    followed_ids.append(follow[Keys.BROADCASTER_ID])
 
         channels = api.get_users(followed_ids)
         if Keys.DATA in channels:


### PR DESCRIPTION
Old API endpoint used for Following Channels (not live!) was apparently deprecated recently, maybe related to [this announcement](https://discuss.dev.twitch.tv/t/legacy-follows-api-and-eventsub-shutdown-timeline-updated/46769)? Can't find any explicit mention of the old users/follows endpoint though.
Anyways, bug report here: https://github.com/anxdpanic/plugin.video.twitch/issues/684

[New endpoint](https://dev.twitch.tv/docs/api/reference/#get-followed-channels) works very similarly, only minor changes required.

Needs change in  script.module.python.twitch as well