### PR TITLE
Add a "Supported codecs" setting (HEVC / Enhanced Broadcasting)

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1005,3 +1005,15 @@ msgstr ""
 msgctxt "#30273"
 msgid "OAuth Token is expired or invalid"
 msgstr ""
+
+msgctxt "#30307"
+msgid "Supported codecs"
+msgstr ""
+
+msgctxt "#30308"
+msgid "Twitch default"
+msgstr ""
+
+msgctxt "#30309"
+msgid "H.265 (HEVC)"
+msgstr ""

--- a/resources/lib/twitch_addon/addon/api.py
+++ b/resources/lib/twitch_addon/addon/api.py
@@ -24,6 +24,13 @@ from twitch.api import usher
 from twitch.api import helix as twitch
 from twitch.api.parameters import Language, Boolean, VideoSort, PeriodHelix
 
+try:
+    from inspect import signature as _signature
+    # Older library versions don't accept the supported_codecs keyword; degrade gracefully.
+    _USHER_SUPPORTS_CODECS = 'supported_codecs' in _signature(usher.live_request).parameters
+except Exception:
+    _USHER_SUPPORTS_CODECS = False
+
 i18n = utils.i18n
 
 
@@ -329,10 +336,17 @@ class Twitch:
         results = self.error_check(results)
         return results
 
+    @staticmethod
+    def _codec_kwargs():
+        codecs = utils.get_supported_codecs()
+        if codecs and _USHER_SUPPORTS_CODECS:
+            return {'supported_codecs': codecs}
+        return {}
+
     @api_error_handler
     @cache.cache_method(cache_limit=cache.limit)
     def get_vod(self, video_id):
-        results = self.usher.video(video_id, headers=self.get_private_credential_headers())
+        results = self.usher.video(video_id, headers=self.get_private_credential_headers(), **self._codec_kwargs())
         return self.error_check(results, private=True)
 
     @api_error_handler
@@ -343,25 +357,25 @@ class Twitch:
     @api_error_handler
     @cache.cache_method(cache_limit=cache.limit)
     def get_live(self, name):
-        results = self.usher.live(name, headers=self.get_private_credential_headers())
+        results = self.usher.live(name, headers=self.get_private_credential_headers(), **self._codec_kwargs())
         return self.error_check(results, private=True)
 
     @api_error_handler
     @cache.cache_method(cache_limit=cache.limit)
     def live_request(self, name):
         if not utils.inputstream_adpative_supports('EXT-X-DISCONTINUITY'):
-            results = self.usher.live_request(name, platform='ps4', headers=self.get_private_credential_headers())
+            results = self.usher.live_request(name, platform='ps4', headers=self.get_private_credential_headers(), **self._codec_kwargs())
         else:
-            results = self.usher.live_request(name, headers=self.get_private_credential_headers())
+            results = self.usher.live_request(name, headers=self.get_private_credential_headers(), **self._codec_kwargs())
         return self.error_check(results, private=True)
 
     @api_error_handler
     @cache.cache_method(cache_limit=cache.limit)
     def video_request(self, video_id):
         if not utils.inputstream_adpative_supports('EXT-X-DISCONTINUITY'):
-            results = self.usher.video_request(video_id, platform='ps4', headers=self.get_private_credential_headers())
+            results = self.usher.video_request(video_id, platform='ps4', headers=self.get_private_credential_headers(), **self._codec_kwargs())
         else:
-            results = self.usher.video_request(video_id, headers=self.get_private_credential_headers())
+            results = self.usher.video_request(video_id, headers=self.get_private_credential_headers(), **self._codec_kwargs())
         return self.error_check(results, private=True)
 
     @staticmethod

--- a/resources/lib/twitch_addon/addon/utils.py
+++ b/resources/lib/twitch_addon/addon/utils.py
@@ -104,6 +104,17 @@ def append_headers(headers):
     return '|%s' % '&'.join(['%s=%s' % (key, quote_plus(headers[key])) for key in headers])
 
 
+# supported_codecs setting -> usher 'supported_codecs' value. Index 0 = Twitch default (omit param).
+SUPPORTED_CODECS = ('', 'h265,h264')
+
+
+def get_supported_codecs():
+    try:
+        return SUPPORTED_CODECS[int(kodi.get_setting('supported_codecs'))]
+    except (ValueError, IndexError):
+        return ''
+
+
 def get_redirect_uri():
     settings_id = kodi.get_setting('oauth_redirecturi')
     stripped_id = settings_id.strip()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -35,6 +35,8 @@
         <setting id="video_support_ia_addon" type="bool" label="" visible="false" enable="true" default="false"/>
         <setting id="video_quality_ia" type="bool" label="30223" default="false" enable="eq(-1,true)|eq(-2,true)"/>
         <setting id="video_quality_ia_configure" type="action" label="30224" enable="eq(-1,true)+eq(-2,true)" visible="eq(-1,true)+eq(-2,true)" option="close" action="RunPlugin(plugin://$ID/?mode=configure_ia)"/>
+        <!-- Supported codecs (Twitch Enhanced Broadcasting: HEVC enables 1440p+ variants; requires hardware decode) -->
+        <setting id="supported_codecs" type="enum" label="30307" lvalues="30308|30309" default="0"/>
         <!-- Title Display -->
         <setting id="title_display" type="enum" label="30045" lvalues="30046|30047|30048|30049|30051|30067|30054" default="0"/>
         <!-- Truncate titles -->


### PR DESCRIPTION
## Summary
Adds a **"Supported codecs"** setting so users can opt in to Twitch **Enhanced Broadcasting** (HEVC), which is required to receive 1440p+ variants.

Addresses #699 (Playback broken for 2k streams) and #700 (No audio on 2k stream): those 2K streams use HEVC, which Twitch only serves when the client requests `supported_codecs`.

## What it does
- New setting **General → "Supported codecs"**: `Twitch default` / `H.265 (HEVC)`.
- The selected value is passed to usher (`live` / `video` / `live_request` / `video_request`) via the new `supported_codecs` parameter.
- **Default = "Twitch default"** → no `supported_codecs` sent → behaviour unchanged (no regression).
- **Opt-in by design**: HEVC requires hardware decode; users without it keep the default. `h264` stays in the requested list as a fallback, so non-HEVC channels/devices still get a playable variant.
- **Graceful fallback**: the value is only passed when the installed `script.module.python.twitch` accepts the parameter (feature-detected), so the plugin still works with an older library.

## Pairs with
The library-side change anxdpanic/script.module.python.twitch#141, which adds the `supported_codecs` parameter. With an older library the setting simply has no effect.

## Testing
- Default setting: usher calls are byte-for-byte unchanged (regression-safe).
- Codec mapping + graceful fallback verified; the `supported_codecs=h265,h264` mechanism is in production use on Raspberry Pi 4 / Kodi 21 (HEVC 1440p plays).
- Uses only standard APIs (stdlib `inspect`); platform-independent.

## Notes
- AV1 is intentionally left out for now (Enhanced Broadcasting AV1 is not generally served); the library parameter is codec-agnostic, so it can be added trivially later.
